### PR TITLE
gamecon_gpio_rpi: fix build on newer kernels by including Device Tree…

### DIFF
--- a/gamecon_gpio_rpi/gamecon_gpio_rpi.c
+++ b/gamecon_gpio_rpi/gamecon_gpio_rpi.c
@@ -37,6 +37,8 @@
 #include <linux/ioport.h>
 #include <linux/version.h>
 #include <asm/io.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
 
 MODULE_AUTHOR("Markus Hiienkari");
 MODULE_DESCRIPTION("NES, SNES, N64, PSX, GC gamepad driver");


### PR DESCRIPTION
Fix build failures on newer kernels caused by missing Device Tree header includes.

Recent kernels/toolchains are stricter about implicit function declarations, which
causes the build to fail when using OF Device Tree helper functions without
including the proper headers.

The driver uses:

of_find_node_by_path()

of_property_read_u32_index()

These are declared in the Device Tree OF headers, but were not explicitly included.
Older kernels likely built successfully due to indirect header inclusion or less
strict compiler behavior.